### PR TITLE
ci: add contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     name: Build Release
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The release workflow failed with 403 when trying to create a GitHub release via softprops/action-gh-release. Adds explicit `permissions: contents: write` to the build-release job.